### PR TITLE
Add floating top bar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
+import TopBar from "@/components/TopBar";
 
 const jakarta = Plus_Jakarta_Sans({
   variable: "--font-manrope",
@@ -15,7 +16,10 @@ export const metadata: Metadata = {
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={jakarta.className}>
-      <body>{children}</body>
+      <body>
+        <TopBar />
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -5,7 +5,7 @@ import React from "react"
 
 export default function HeroSection() {
   return (
-    <section className="bg-black text-white px-6 py-10 md:py-20 text-center">
+    <section id="hero-section" className="bg-black text-white px-6 py-10 md:py-20 text-center">
       {/* Logo */}
       <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">roastr</h1>
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { useEffect, useState } from "react"
+import { Bars3Icon } from "@heroicons/react/24/solid"
+
+export default function TopBar() {
+  const pathname = usePathname()
+  const [visible, setVisible] = useState(pathname !== "/")
+
+  useEffect(() => {
+    if (pathname !== "/") {
+      setVisible(true)
+      return
+    }
+    const hero = document.getElementById("hero-section")
+    if (!hero) {
+      setVisible(true)
+      return
+    }
+
+    const handleScroll = () => {
+      const show = window.scrollY >= hero.clientHeight
+      setVisible(show)
+    }
+
+    handleScroll()
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [pathname])
+
+  return (
+    <div
+      className={`fixed top-0 left-0 z-50 w-full transition-transform ${
+        visible ? "translate-y-0" : "-translate-y-full"
+      }`}
+    >
+      <div className="bg-white/80 backdrop-blur border-b border-gray-200">
+        <div className="max-w-screen-lg mx-auto px-4 py-2 flex items-center justify-between">
+          <Link href="/" className="font-bold text-lg">
+            roastr
+          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/review"
+              className="bg-white border border-black hover:bg-black hover:text-white px-3 py-1.5 rounded-md text-sm font-semibold transition-colors"
+            >
+              Write a review
+            </Link>
+            <button aria-label="Menu" className="p-2">
+              <Bars3Icon className="w-6 h-6" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add floating `TopBar` with logo, review button, hamburger menu
- show `TopBar` everywhere and only after scrolling past hero on the home page
- mark hero section so it can be detected

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842f3c2ecf8832c94709d90115d2bc9