### PR TITLE
Add search query page

### DIFF
--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default async function QueryPage({ searchParams }: { searchParams: Promise<{ q?: string }> }) {
+  const { q } = await searchParams;
+  const query = q || "";
+  return (
+    <main className="max-w-screen-lg mx-auto px-4 sm:px-6 pt-24 space-y-6">
+      <h1 className="text-xl font-semibold">Search Results{query ? ` for "${query}"` : ""}</h1>
+      <div className="text-center py-10">
+        <p className="mb-4 text-sm text-gray-600">No results found.</p>
+        <Link
+          href="/review"
+          className="bg-white border border-black hover:bg-black hover:text-white px-3 py-1.5 rounded-md text-sm font-semibold transition-colors"
+        >
+          ✍️ Write a review
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,9 +1,18 @@
 "use client"
 
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid"
-import React from "react"
+import React, { useState } from "react"
+import { useRouter } from "next/navigation"
 
 export default function HeroSection() {
+  const router = useRouter()
+  const [query, setQuery] = useState("")
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push(`/query${query ? `?q=${encodeURIComponent(query)}` : ""}`)
+  }
+
   return (
     <section id="hero-section" className="bg-black text-white px-6 py-10 md:py-20 text-center">
       {/* Logo */}
@@ -16,14 +25,16 @@ export default function HeroSection() {
       </p>
 
       {/* Search Input with Icon */}
-      <div className="relative max-w-xl mx-auto mb-6">
+      <form onSubmit={handleSubmit} className="relative max-w-xl mx-auto mb-6">
         <MagnifyingGlassIcon className="w-5 h-5 text-gray-400 absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none" />
         <input
           type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
           placeholder="search beans, roasters, or flavors..."
           className="w-full pl-12 pr-5 py-3 md:py-4 rounded-full text-sm md:text-base text-black bg-white placeholder-gray-500 shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400"
         />
-      </div>
+      </form>
 
       {/* Review count */}
       <p className="text-xs md:text-sm text-gray-400 mb-1">

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
-import { Bars3Icon } from "@heroicons/react/24/solid"
 
 export default function TopBar() {
   const pathname = usePathname()


### PR DESCRIPTION
## Summary
- add a `/query` route with placeholder empty state
- link HeroSection search input to redirect to `/query` on submit
- clean up unused icon import in TopBar
- fix `query` page to await `searchParams`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font)*

------
https://chatgpt.com/codex/tasks/task_e_6842f80678dc832caa7a0e0df2bdc28b