### PR TITLE
Refactor slider to keep server page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,41 +2,16 @@
 
 //import UI components
 import HeroSection from "@/components/HeroSection"
-import BeanCard from "@/components/BeanCard"
 import ReviewCard from "@/components/ReviewCard"
+import BeansSlider from "@/components/BeansSlider"
 
 //import functions and data
-import "keen-slider/keen-slider.min.css"
-import { useKeenSlider } from "keen-slider/react"
 import { beans } from "@/data/beans"
 
 import { mockBeanData } from "@/data/mockBeanData"
 
-//Top Beans keenSlider config
+// Top Beans and Recent Reviews
 export default function Home() {
-  const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
-  slides: {
-    perView: 2, // Base mobile
-    spacing: 10,
-  },
-  breakpoints: {
-    // "(min-width: 200px)": {
-    //   slides: { perView: 1.8, spacing: 18 }, // iPhone 12+
-    // },
-    "(min-width: 425px)": {
-      slides: { perView: 2.5, spacing: 10 }, // Larger phones
-    },
-    "(min-width: 550px)": {
-      slides: { perView: 3, spacing: 20 }, // Tablets portrait
-    },
-    "(min-width: 640px)": {
-      slides: { perView: 2.6, spacing: 28 }, // iPad landscape
-    },
-    "(min-width: 850px)": {
-      slides: { perView: 3.4, spacing: 10 }, // Desktop
-    },
-  },
-  })
   
 // Mock reviews data
   const reviews = Object.values(mockBeanData).flatMap((bean) =>
@@ -57,41 +32,14 @@ export default function Home() {
         
       {/* Beans Section */}
       <section className="relative overflow-visible">
-        {/* Header Row */}
-
         <div className="flex justify-between items-center mb-4">
           <div>
             <h2 className="text-2xl font-bold">Beans of The Month</h2>
             <p className="text-gray-600 text-xs">highly roastr rated beans, according to you!</p>
           </div>
-
-          {/* Buttons */}
-          <div className="hidden md:flex gap-2">
-            <button
-              onClick={() => instanceRef.current?.prev()}
-              aria-label="Previous"
-              className="w-10 h-10 flex items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 shadow"
-            >
-              ◀
-            </button>
-            <button
-              onClick={() => instanceRef.current?.next()}
-              aria-label="Next"
-              className="w-10 h-10 flex items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 shadow"
-            >
-              ▶
-            </button>
-          </div>
         </div>
 
-        {/* Slider */}
-        <div ref={sliderRef} className="keen-slider overflow-visible">
-          {beans.map((bean, i) => (
-            <div key={i} className="keen-slider__slide !w-auto pr-4 pb-2">
-              <BeanCard {...bean} />
-            </div>
-          ))}
-        </div>
+        <BeansSlider beans={beans} />
       </section>
 
       {/* Divider */}

--- a/src/utils/supabase/fetchBeansWithRelations.ts
+++ b/src/utils/supabase/fetchBeansWithRelations.ts
@@ -59,7 +59,7 @@ export async function fetchBeansWithRelations(): Promise<Bean[]> {
     return []
   }
 
-  return (data ?? []).map((bean: any) => ({
+  return (data ?? []).map((bean: Bean) => ({
     ...bean,
     roaster_id: Array.isArray(bean.roaster_id) ? (bean.roaster_id[0] ?? null) : bean.roaster_id,
   }))


### PR DESCRIPTION
## Summary
- keep `Home` as a server component by moving slider logic into `BeansSlider`
- fix lint error in Supabase fetch helper

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Plus Jakarta Sans`)*

------
https://chatgpt.com/codex/tasks/task_e_6849395de058832c8829cba7789a2a3d