### PR TITLE
Add supabase search functionality

### DIFF
--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -1,22 +1,46 @@
 import Link from "next/link";
+import BeanCard from "@/components/BeanCard";
+import { searchBeans } from "@/lib/searchBeans";
 
-
-export default async function QueryPage({ searchParams }: { searchParams: Promise<{ q?: string }> }) {
+export default async function QueryPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
   const { q } = await searchParams;
-  const query = q || "";
+  const query = q?.trim() || "";
+  const beans = query ? await searchBeans(query) : [];
 
   return (
     <main className="max-w-screen-lg mx-auto px-4 sm:px-6 pt-24 space-y-6">
-      <h1 className="text-xl font-semibold">Search Results{query ? ` for "${query}"` : ""}</h1>
-      <div className="text-center py-10">
-        <p className="mb-4 text-sm text-gray-600">No results found.</p>
-        <Link
-          href="/review"
-          className="bg-white border border-black hover:bg-black hover:text-white px-3 py-1.5 rounded-md text-sm font-semibold transition-colors"
-        >
-          ✍️ Write a review
-        </Link>
-      </div>
+      <h1 className="text-xl font-semibold">
+        Search Results{query ? ` for "${query}"` : ""}
+      </h1>
+      {beans.length > 0 ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {beans.map((bean) => (
+            <BeanCard
+              key={bean.id}
+              slug={bean.slug}
+              image={bean.image_url}
+              roaster={bean.roaster?.name ?? "Unknown Roaster"}
+              name={bean.name}
+              average_score={Number(bean.average_score ?? 0)}
+              ratings_count={Number(bean.ratings_count ?? 0)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-10">
+          <p className="mb-4 text-sm text-gray-600">No results found.</p>
+          <Link
+            href="/review"
+            className="bg-white border border-black hover:bg-black hover:text-white px-3 py-1.5 rounded-md text-sm font-semibold transition-colors"
+          >
+            ✍️ Write a review
+          </Link>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/lib/searchBeans.ts
+++ b/src/lib/searchBeans.ts
@@ -1,0 +1,37 @@
+import { createClient } from '../utils/supabase/server'
+
+export type SearchBean = {
+  id: string
+  slug: string
+  name: string
+  image_url: string
+  average_score: number | null
+  ratings_count: number | null
+  roaster: {
+    name: string
+  } | null
+}
+
+export async function searchBeans(query: string, limit = 10): Promise<SearchBean[]> {
+  const supabase = await createClient()
+
+  if (!query) return []
+
+  const { data, error } = await supabase
+    .from('beans')
+    .select(
+      `id, slug, name, image_url, average_score, ratings_count, roaster:roaster_id(name)`
+    )
+    .or(`name.ilike.%${query}%, roaster.name.ilike.%${query}%`)
+    .limit(limit)
+
+  if (error || !data) {
+    console.error('Error searching beans:', error?.message)
+    return []
+  }
+
+  return data.map((bean) => ({
+    ...bean,
+    roaster: Array.isArray(bean.roaster) ? bean.roaster[0] ?? null : bean.roaster,
+  })) as SearchBean[]
+}


### PR DESCRIPTION
## Summary
- add `searchBeans` helper to query Supabase
- update search results page to list matched beans

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font)*

------
https://chatgpt.com/codex/tasks/task_e_6849b248fb98832c97ede23145131b2b