### PR TITLE
Add roaster details page

### DIFF
--- a/src/app/roaster/[slug]/page.tsx
+++ b/src/app/roaster/[slug]/page.tsx
@@ -1,0 +1,88 @@
+import Image from 'next/image'
+import { notFound } from 'next/navigation'
+import BeanCard from '@/components/BeanCard'
+import { fetchRoasterBySlug } from '@/lib/fetchRoasterBySlug'
+import { supabase } from '@/lib/supabaseClient'
+
+interface RoasterParams {
+  slug: string
+}
+
+export async function generateStaticParams() {
+  const { data, error } = await supabase.from('roasters').select('slug')
+
+  if (error || !data) return []
+
+  return data.map((roaster) => ({ slug: roaster.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<RoasterParams> }) {
+  const { slug } = await params
+  const roaster = await fetchRoasterBySlug(slug)
+
+  if (!roaster) {
+    return {
+      title: 'Roaster Not Found | roastr',
+      description: 'We couldn\u2019t find that roaster. Explore more on roastr.',
+    }
+  }
+
+  return {
+    title: `${roaster.name} | roastr`,
+    description: roaster.description ?? '',
+  }
+}
+
+export default async function RoasterPage({ params }: { params: Promise<RoasterParams> }) {
+  const { slug } = await params
+  const roaster = await fetchRoasterBySlug(slug)
+
+  if (!roaster) return notFound()
+
+  return (
+    <main className="max-w-screen-md mx-auto px-4 sm:px-6 py-10 space-y-6 pt-20">
+      {/* Logo */}
+      <div className="relative h-[200px] sm:h-[300px] w-full rounded-lg border-2 border-gray-800">
+        <Image
+          src={roaster.logo_url}
+          alt={roaster.name}
+          fill
+          className="object-contain"
+          sizes="(min-width: 768px) 500px, 100vw"
+        />
+      </div>
+
+      {/* Header */}
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold">{roaster.name}</h1>
+        {roaster.location && <p className="text-sm text-gray-600">{roaster.location}</p>}
+      </div>
+
+      {/* Description */}
+      <div className="text-sm text-gray-800 space-y-4">
+        <p>{roaster.description}</p>
+      </div>
+
+      {/* Divider */}
+      <hr className="my-8 border-t border-gray-800" />
+
+      {/* Beans */}
+      <div>
+        <h2 className="text-lg font-semibold mb-4">Beans</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          {roaster.beans.map((bean, i) => (
+            <BeanCard
+              key={i}
+              image={bean.image_url}
+              roaster={roaster.name}
+              name={bean.name}
+              average_score={bean.average_score ?? 0}
+              ratings_count={bean.ratings_count ?? 0}
+              slug={bean.slug}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/fetchRoasterBySlug.ts
+++ b/src/lib/fetchRoasterBySlug.ts
@@ -1,0 +1,57 @@
+import { createClient } from '../utils/supabase/server'
+
+export type RoasterBean = {
+  slug: string
+  name: string
+  image_url: string
+  average_score: number | null
+  ratings_count: number | null
+}
+
+export type Roaster = {
+  id: string
+  slug: string
+  name: string
+  location: string | null
+  description: string | null
+  logo_url: string
+  beans: RoasterBean[]
+}
+
+export async function fetchRoasterBySlug(slug: string) {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('roasters')
+    .select(`
+      id,
+      slug,
+      name,
+      location,
+      description,
+      logo_url,
+      beans:beans(
+        slug,
+        name,
+        image_url,
+        average_score,
+        ratings_count
+      )
+    `)
+    .eq('slug', slug)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Error fetching roaster by slug:', error.message)
+    return null
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return {
+    ...data,
+    beans: Array.isArray(data.beans) ? data.beans : []
+  } as Roaster
+}


### PR DESCRIPTION
## Summary
- fetch roaster data by slug
- add `/roaster/[slug]` route
- show roaster info and beans

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ab259eae4832ca4af674e46b80997