### PR TITLE
Integrate sidebar with hero and top bar

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,6 +4,7 @@ import { MagnifyingGlassIcon } from "@heroicons/react/24/solid"
 import React, { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link";
+import Sidebar from "./sideBar"
 
 export default function HeroSection() {
   const router = useRouter()
@@ -16,6 +17,11 @@ export default function HeroSection() {
 
   return (
     <section id="hero-section" className="relative bg-black text-white px-6 py-10 md:py-20 text-center">
+
+      {/* Sidebar trigger in top-left */}
+      <div className="absolute top-3 left-4">
+        <Sidebar />
+      </div>
 
       {/* 🔹 About Us link in top-right corner */}
       <Link
@@ -30,7 +36,7 @@ export default function HeroSection() {
 
       {/* Subtitle */}
       <p className="text-xs md:text-lg text-gray-300 max-w-xl mx-auto mb-8 leading-relaxed">
-        Explore Indo's best specialty coffee, and share your Brew! <br className="md:hidden" />
+        Explore Indo&apos;s best specialty coffee, and share your Brew! <br className="md:hidden" />
       </p>
 
       {/* Search Input */}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
+import Sidebar from "./sideBar"
 
 export default function TopBar() {
   const pathname = usePathname()
@@ -39,10 +40,13 @@ export default function TopBar() {
     <div className="bg-black">
       <div className="max-w-screen-lg mx-auto px-4 py-2 flex items-center justify-between">
         
-        {/* Left: Logo */}
-        <Link href="/" className="font-bold text-lg text-white hover:text-gray-300 transition-colors">
-          roastr
-        </Link>
+        {/* Left: Sidebar toggle and Logo */}
+        <div className="flex items-center gap-4">
+          <Sidebar />
+          <Link href="/" className="font-bold text-lg text-white hover:text-gray-300 transition-colors">
+            roastr
+          </Link>
+        </div>
 
         {/* Right: Links */}
         <div className="flex items-center gap-4">

--- a/src/components/sideBar.tsx
+++ b/src/components/sideBar.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { XMarkIcon, Bars3Icon } from '@heroicons/react/24/solid'
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
 
   // Close on Esc key
   useEffect(() => {
@@ -15,6 +17,9 @@ export default function Sidebar() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
+
+  // Ensure portal is rendered client-side only
+  useEffect(() => setMounted(true), [])
 
   return (
     <>
@@ -26,38 +31,43 @@ export default function Sidebar() {
       >
         <Bars3Icon className="w-6 h-6" />
       </button>
+      {mounted &&
+        createPortal(
+          <>
+            {/* Overlay */}
+            {open && (
+              <div
+                onClick={() => setOpen(false)}
+                className="fixed inset-0 bg-gray-600/50 z-[9999]"
+              />
+            )}
 
-      {/* Overlay */}
-      {open && (
-        <div
-          onClick={() => setOpen(false)}
-          className="fixed inset-0 bg-gray-600/50 z-[9999]"
-        />
-      )}
+            {/* Sidebar from left */}
+            <div
+              className={`fixed top-0 left-0 h-full bg-white text-black z-[9999] transform transition-transform duration-300 ease-in-out
+                ${open ? 'translate-x-0' : '-translate-x-full'}
+                w-64 md:w-80`
+              }
+            >
+              <div className="flex justify-between items-center px-4 py-3 border-b border-gray-200">
+                <span className="font-semibold text-lg">Menu</span>
+                <button onClick={() => setOpen(false)} aria-label="Close menu">
+                  <XMarkIcon className="w-6 h-6 text-gray-600 hover:text-black" />
+                </button>
+              </div>
 
-      {/* Sidebar from left */}
-      <div
-        className={`fixed top-0 left-0 h-full bg-white text-black z-[9999] transform transition-transform duration-300 ease-in-out
-          ${open ? 'translate-x-0' : '-translate-x-full'}
-          w-64 md:w-80`
-        }
-      >
-        <div className="flex justify-between items-center px-4 py-3 border-b border-gray-200">
-          <span className="font-semibold text-lg">Menu</span>
-          <button onClick={() => setOpen(false)} aria-label="Close menu">
-            <XMarkIcon className="w-6 h-6 text-gray-600 hover:text-black" />
-          </button>
-        </div>
-
-        <nav className="flex flex-col gap-4 px-4 py-6 text-sm">
-          <Link href="/roasters" onClick={() => setOpen(false)} className="hover:text-gray-700">
-            Roasters
-          </Link>
-          <Link href="/about" onClick={() => setOpen(false)} className="hover:text-gray-700">
-            About Us
-          </Link>
-        </nav>
-      </div>
+              <nav className="flex flex-col gap-4 px-4 py-6 text-sm">
+                <Link href="/roasters" onClick={() => setOpen(false)} className="hover:text-gray-700">
+                  Roasters
+                </Link>
+                <Link href="/about" onClick={() => setOpen(false)} className="hover:text-gray-700">
+                  About Us
+                </Link>
+              </nav>
+            </div>
+          </>,
+          document.body
+        )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- render the sidebar globally using a portal so it can overlay the whole page
- add sidebar trigger to the HeroSection and TopBar
- fix linter issue with apostrophe in HeroSection

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d16e48768832c8b85b622e07c8d2f